### PR TITLE
Restrict settings page auto display to initial install only

### DIFF
--- a/src/service-worker/service-worker.js
+++ b/src/service-worker/service-worker.js
@@ -7,11 +7,13 @@ import {
   webNavigation,
 } from '../infrastructure/browser.js';
 
-runtime.onInstalled.addListener(() =>
-  runtime
-    .openOptionsPage()
-    .catch((err) => console.error('Extension API error: ', err)),
-);
+runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    runtime
+      .openOptionsPage()
+      .catch((err) => console.error('Extension API error: ', err));
+  }
+});
 
 const extractParams = (searchParams) => {
   // Join multiple 'text' and 'url' parameters with commas (same behavior as X)


### PR DESCRIPTION
This pull request introduces a fix for the bug where the extension's settings page is incorrectly displayed after a browser update, contrary to the expected behavior where it should only appear upon the initial installation of the extension.

#3 