### PR TITLE
Update directory structure for Brazilian Portuguese

### DIFF
--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "ShareSwitch - Redireciona botões de compartilhamento do Twitter para Bluesky, Mastodon e mais"
+    "message": "ShareSwitch -Redireciona botões de compartilhamento do Twitter para Bluesky"
   },
   "extensionDescription": {
     "message": "Redireciona botões de compartilhamento do X (antigo Twitter) para suas plataformas favoritas de microblogging"


### PR DESCRIPTION
- When submitting to the Chrome Web Store, it is necessary to specify the language with regional distinctions, such as Brazilian Portuguese (pt_BR) or European Portuguese (pt_PT), rather than just using Portuguese (pt). 

- The name field in the manifest.json file must be 75 characters or less. 